### PR TITLE
Fix TouchEvents being blocked by non-visible list elements

### DIFF
--- a/components/SelectableSectionsListView.js
+++ b/components/SelectableSectionsListView.js
@@ -255,7 +255,8 @@ export default class SelectableSectionsListView extends Component {
       renderFooter,
       renderHeader,
       renderRow: this.renderRow,
-      renderSectionHeader
+      renderSectionHeader,
+      removeClippedSubviews: false
     });
 
     props.style = void 0;


### PR DESCRIPTION
It looks like (at least in some cases) there can be ListView elements which are outside the ScrollView, which block the interaction with the visible list elements.
I could not figure out what is going wrong with these elements (how they end up in front of the UI and why they block UI interaction), but apparently, if `removeClippedSubviews` on the ListView is set to `false` is a workaround for this issue.

Looking forward to feedback and improvement suggestions.

*Note:* This is merely a quick&dirty workaround. It might cause some performance penalties, as all list items will be rendered from the start.